### PR TITLE
Added support for generated tiles with no supports

### DIFF
--- a/MakeTile/tile_creation/Connecting_Column_Tiles.py
+++ b/MakeTile/tile_creation/Connecting_Column_Tiles.py
@@ -82,6 +82,7 @@ class MT_PT_Connecting_Column_Panel(Panel):
 
         if scene_props.base_blueprint not in ('PLAIN', 'NONE'):
             layout.prop(scene_props, 'base_socket_type')
+            layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Material")
         layout.prop(scene_props, 'column_material')
@@ -202,6 +203,7 @@ class MT_OT_Make_Connecting_Column_Tile(Operator, MT_Tile_Generator):
         layout.prop(self, 'column_socket_style')
         if self.base_blueprint not in ('PLAIN', 'NONE'):
             layout.prop(self, 'base_socket_type')
+            layout.prop(scene_props, 'generate_suppports')
 
         layout.prop(self, 'displacement_thickness')
 
@@ -504,7 +506,7 @@ def spawn_openlock_L_cutters(base, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter and add to collection
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -598,7 +600,7 @@ def spawn_openlock_T_cutters(base, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter and add to collection
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -719,7 +721,7 @@ def spawn_openlock_X_cutters(base, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter and add to collection
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -870,7 +872,7 @@ def spawn_socket_buffers(cutters, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load buffer mesh
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -907,7 +909,7 @@ def spawn_openlock_I_cutters(base, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter and add to collection
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -991,7 +993,7 @@ def spawn_openlock_O_cutters(base, tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter and add to collection
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):

--- a/MakeTile/tile_creation/Curved_Tiles.py
+++ b/MakeTile/tile_creation/Curved_Tiles.py
@@ -513,7 +513,7 @@ def spawn_openlock_wall_cutters(tile_props):
         preferences.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):

--- a/MakeTile/tile_creation/L_Tiles.py
+++ b/MakeTile/tile_creation/L_Tiles.py
@@ -582,7 +582,7 @@ def spawn_openlock_wall_cutters(self, core, tile_props):
         preferences.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):

--- a/MakeTile/tile_creation/Roofs.py
+++ b/MakeTile/tile_creation/Roofs.py
@@ -79,6 +79,7 @@ class MT_PT_Roof_Panel(Panel):
         layout.prop(scene_props, 'base_bottom_socket_type', text="")
         # layout.prop(roof_props, 'base_side_socket_type')
         # layout.prop(roof_props, 'gable_socket_type')
+        layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Roof Footprint")
         row = layout.row()
@@ -272,6 +273,7 @@ class MT_OT_Make_Roof(Operator, MT_Tile_Generator):
         layout.prop(self, 'base_bottom_socket_type', text="")
         # layout.prop(roof_props, 'base_side_socket_type')
         # layout.prop(roof_props, 'gable_socket_type')
+        layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Roof Footprint")
         row = layout.row()

--- a/MakeTile/tile_creation/Semi_Circ_Tiles.py
+++ b/MakeTile/tile_creation/Semi_Circ_Tiles.py
@@ -89,6 +89,7 @@ class MT_PT_Semi_Circ_Floor_Panel(Panel):
 
         if scene_props.base_blueprint not in ('PLAIN', 'NONE'):
             layout.prop(scene_props, 'base_socket_type')
+            layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Material")
         layout.prop(scene_props, 'floor_material')
@@ -201,6 +202,7 @@ class MT_OT_Make_Semi_Circ_Floor_Tile(Operator, MT_Tile_Generator):
 
         if self.base_blueprint not in ('PLAIN', 'NONE'):
             layout.prop(self, 'base_socket_type')
+            layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Material")
         layout.prop(self, 'floor_material')

--- a/MakeTile/tile_creation/Straight_Tiles.py
+++ b/MakeTile/tile_creation/Straight_Tiles.py
@@ -73,6 +73,7 @@ class MT_PT_Straight_Wall_Panel(Panel):
 
         if 'base_blueprint' in blueprints and scene_props.base_blueprint not in ('PLAIN', 'NONE'):
             layout.prop(scene_props, 'base_socket_type')
+            layout.prop(scene_props, 'generate_suppports')
 
         layout.label(text="Materials")
 
@@ -510,7 +511,7 @@ def spawn_openlock_wall_cutters(core, base, tile_props):
         preferences.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):

--- a/MakeTile/tile_creation/U_Tiles.py
+++ b/MakeTile/tile_creation/U_Tiles.py
@@ -311,7 +311,7 @@ def spawn_openlock_wall_cutters(base, tile_props):
         preferences.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load side cutter
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
@@ -775,7 +775,7 @@ def spawn_openlock_base_slot_cutter(tile_props):
         preferences.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):
         data_to.objects = [

--- a/MakeTile/tile_creation/create_tile.py
+++ b/MakeTile/tile_creation/create_tile.py
@@ -472,6 +472,12 @@ class MT_Tile_Generator:
         name="Base socket type",
         description="What type of base socket to use."
     )
+    
+    generate_suppports: BoolProperty(
+        default=True,
+        name="Generate Supports",
+        description="If checked, openlock connectors will have supports generated for them."
+    )
 
     @classmethod
     def poll(cls, context):
@@ -590,7 +596,7 @@ class MT_Tile_Generator:
         """
         sockets = [
             {'socket_type': 'OPENLOCK',
-             'filename': 'openlock.blend'},
+             'filename': "openlock.blend" if self.generate_suppports else "openlockNoSupport.blend"},
             {'socket_type': 'LASTLOCK',
              'filename': 'lastlock.blend'}]
         for socket in sockets:
@@ -968,7 +974,7 @@ def load_openlock_top_peg(tile_props):
         prefs.assets_path,
         "meshes",
         "booleans",
-        "openlock.blend")
+        "openlock.blend" if tile_props.generate_suppports else "openlockNoSupport.blend")
 
     # load peg bool
     with bpy.data.libraries.load(booleans_path) as (data_from, data_to):

--- a/MakeTile/tile_creation/tile_panels.py
+++ b/MakeTile/tile_creation/tile_panels.py
@@ -15,6 +15,7 @@ def scene_tile_panel_header(scene_props, layout, blueprints, tile_type):
 
     if 'base_blueprint' in blueprints and 'OPENLOCK' in scene_props.base_blueprint:
         layout.prop(scene_props, 'base_socket_type')
+        layout.prop(scene_props, 'generate_suppports')
 
     layout.label(text="Materials")
     if tile_type == 'FLOOR':
@@ -132,6 +133,7 @@ def redo_tile_panel_header(self, layout, blueprints, tile_type):
 
     if 'base_blueprint' in blueprints and 'OPENLOCK' in self.base_blueprint:
         layout.prop(self, 'base_socket_type')
+        layout.prop(scene_props, 'generate_suppports')
 
     layout.label(text='Materials')
     if tile_type == 'FLOOR':
@@ -183,6 +185,7 @@ def redo_curved_tiles_panel(self, layout):
     """
     if self.base_blueprint not in ('PLAIN', 'NONE'):
         layout.prop(self, 'base_socket_type')
+        layout.prop(scene_props, 'generate_suppports')
 
     layout.label(text="Tile Properties")
     layout.prop(self, 'tile_z', text="Height")


### PR DESCRIPTION
This update adds support for tiles with no pregenerated supports. This allows for easy vertical printing of tiles, or for the use of slicer-generated supports (which in my experience are easier to remove and higher quality).

I implemented this in the first way I found possible, without understanding the full code. While it seems to function just fine, it might not be up to the standards of this project. I'm mostly submitting this pull request so that others, if they really need this functionality before richeyrose returns to work on it, have something at least.

The openlock.blend file doesn't seem to be included in the repository in the same way it is in the release, so I only included the custom file I used to hold the supportless cutting meshes.